### PR TITLE
Support loading conf from conda install

### DIFF
--- a/src/dgenies/config_reader.py
+++ b/src/dgenies/config_reader.py
@@ -24,7 +24,8 @@ class AppConfigReader:
                               "/etc/dgenies/application.properties",
                               "/etc/dgenies/application.properties.local",
                               os.path.join(str(Path.home()), ".dgenies", "application.properties"),
-                              os.path.join(str(Path.home()), ".dgenies", "application.properties.local")]
+                              os.path.join(str(Path.home()), ".dgenies", "application.properties.local"),
+                              os.path.join(self.app_dir, '..', 'etc', 'dgenies', 'application.properties')]
 
         if os.name == "nt":
             config_file.insert(1, os.path.join(sys.executable, '..', "application.properties"))

--- a/src/dgenies/tools.py
+++ b/src/dgenies/tools.py
@@ -104,20 +104,19 @@ class Tools:
         self.load_yaml()
 
     def load_yaml(self):
-        self.app_dir = os.path.dirname(inspect.getfile(self.__class__))
+        app_dir = os.path.dirname(inspect.getfile(self.__class__))
         yaml_file = None
         config_file_search = [os.path.join(os.path.abspath(os.sep), "dgenies", "tools.yaml"),
                               "/etc/dgenies/tools.yaml",
                               "/etc/dgenies/tools.yaml.local",
                               os.path.join(str(Path.home()), ".dgenies", "tools.yaml"),
                               os.path.join(str(Path.home()), ".dgenies", "tools.yaml.local"),
-                              os.path.join(self.app_dir, '..', 'etc', 'dgenies', 'tools.yaml')]
+                              os.path.join(app_dir, '..', 'etc', 'dgenies', 'tools.yaml')]
 
         if os.name == "nt":
             config_file_search.insert(1, os.path.join(sys.executable, '..', "tools.yaml"))
             config_file_search.insert(1, os.path.join(sys.executable, '..', "tools.yaml.local"))
 
-        app_dir = os.path.dirname(inspect.getfile(self.__class__))
         config_file_search.append(os.path.join(app_dir, "tools-dev.yaml"))
         config_file_search.append(os.path.join(app_dir, "tools-dev.yaml.local"))
 

--- a/src/dgenies/tools.py
+++ b/src/dgenies/tools.py
@@ -104,12 +104,14 @@ class Tools:
         self.load_yaml()
 
     def load_yaml(self):
+        self.app_dir = os.path.dirname(inspect.getfile(self.__class__))
         yaml_file = None
         config_file_search = [os.path.join(os.path.abspath(os.sep), "dgenies", "tools.yaml"),
                               "/etc/dgenies/tools.yaml",
                               "/etc/dgenies/tools.yaml.local",
                               os.path.join(str(Path.home()), ".dgenies", "tools.yaml"),
-                              os.path.join(str(Path.home()), ".dgenies", "tools.yaml.local")]
+                              os.path.join(str(Path.home()), ".dgenies", "tools.yaml.local"),
+                              os.path.join(self.app_dir, '..', 'etc', 'dgenies', 'tools.yaml')]
 
         if os.name == "nt":
             config_file_search.insert(1, os.path.join(sys.executable, '..', "tools.yaml"))


### PR DESCRIPTION
A possible fix for #12 
I guess adding this relative path as a last possbility should work in many situations (including conda) without breaking anything for people already running dgenies
What do you think?