### PR TITLE
add path for conda installation tested on OSX and Linux

### DIFF
--- a/src/dgenies/config_reader.py
+++ b/src/dgenies/config_reader.py
@@ -25,17 +25,17 @@ class AppConfigReader:
                               "/etc/dgenies/application.properties.local",
                               os.path.join(str(Path.home()), ".dgenies", "application.properties"),
                               os.path.join(str(Path.home()), ".dgenies", "application.properties.local")]
-
         if os.name == "nt":
-            config_file.insert(1, os.path.join(sys.executable, '..', "application.properties"))
-            config_file.insert(1, os.path.join(sys.executable, '..', "application.properties.local"))
+            config_file_search.insert(1, os.path.join(sys.executable, '..', "application.properties"))
+            config_file_search.insert(1, os.path.join(sys.executable, '..', "application.properties.local"))
+
+        config_file_search.append(os.path.join(self.app_dir, "application-dev.properties"))
+        config_file_search.append(os.path.join(self.app_dir, '..', "etc", "dgenies", "application.properties"))
+        config_file_search.append(os.path.join(self.app_dir, "application-dev.properties.local"))
 
         for my_config_file in config_file_search:
             if os.path.exists(my_config_file):
                 config_file.append(my_config_file)
-
-        config_file.append(os.path.join(self.app_dir, "application-dev.properties"))
-        config_file.append(os.path.join(self.app_dir, "application-dev.properties.local"))
 
         if len(config_file) == 0:
             raise FileNotFoundError("ERROR: application.properties not found.")

--- a/src/dgenies/tools.py
+++ b/src/dgenies/tools.py
@@ -117,6 +117,7 @@ class Tools:
 
         app_dir = os.path.dirname(inspect.getfile(self.__class__))
         config_file_search.append(os.path.join(app_dir, "tools-dev.yaml"))
+        config_file_search.append(os.path.join(app_dir, '..', "etc", "dgenies", "tools.yaml"))
         config_file_search.append(os.path.join(app_dir, "tools-dev.yaml.local"))
 
         for my_config_file in reversed(config_file_search):


### PR DESCRIPTION
Hi @chklopp here another solution for fixing #12.
The first solution is #13. I don't know if @abretaud tested it but his solution sounds good (I just realised the existence of his patch when I started my PR :/ ).
Otherwise I have a patch too in this PR that I tested on Conda installation on OSX and Linux. 

Everyone would benefit to have dgenies available in conda. I hope you will soon make a release that include one of the fixes for installation via conda. 