### PR TITLE
Fix typo: tool_options → tool_option

### DIFF
--- a/src/dgenies/api/__init__.py
+++ b/src/dgenies/api/__init__.py
@@ -490,7 +490,8 @@ def prepare_jobs(email: str, jobs: list[Job]) -> list[dict]:
             "align_type": job.align_type.value if job.align else None,
             "backup": job.backup if job.backup else None,
             "backup_type": job.backup_type.value if job.backup else None,
-            "options": " ".join(get_tools_options(job.tool.value, job.tool_options)) if job.tool_options else None
+            "options": " ".join(get_tools_options(job.tool.value, job.tool_option)) if job.tool_option else None
+
         })
     return result
 


### PR DESCRIPTION
Correction de l'appel à job.tool_options dans prepare_jobs (backend aligné avec le frontend).