### PR TITLE
feat(api): support dotplot annotation tracks

### DIFF
--- a/src/dgenies/api/__init__.py
+++ b/src/dgenies/api/__init__.py
@@ -13,7 +13,7 @@ from typing import (
 
 import itertools as it
 
-from flask import current_app, make_response
+from flask import current_app, make_response, send_file
 from flask_openapi3 import APIBlueprint
 from werkzeug.exceptions import RequestEntityTooLarge
 
@@ -32,6 +32,7 @@ from ..lib.exceptions import (
 from ..lib.functions import Functions
 from ..lib.job_manager import JobManager
 from ..lib.paf import Paf
+from ..lib.annotation_tracks import AnnotationTrackError, AnnotationTracks
 
 from .datamodels import (
     BaseResponse,
@@ -45,12 +46,14 @@ from .datamodels import (
     GalleryResponse,
     JobFilePath,
     JobPath,
+    AnnotationTrackPath,
     BatchSubmissionResponse,
     BatchSubmissionQuery,
     Limits,
     Session,
     SessionResponse,
     UploadFileForm,
+    AnnotationTrackUploadForm,
     JobStatus,
     JobStatusResponse,
     JobDescription,
@@ -68,7 +71,9 @@ from .datamodels import (
     PrepareFasta,
     PrepareFastaInput,
     PrepareFastaEnum,
-    PrepareFastaResponse
+    PrepareFastaResponse,
+    AnnotationTrackResponse,
+    AnnotationTracksResponse
 )
 from .job_descriptions import job_descriptions
 from ..lib.upload_file import UploadFile
@@ -623,14 +628,14 @@ def prepare_jobs(email: str, jobs: list[Job]) -> list[dict]:
             "type": job.type,
             "email": email,
             "query": job.query if job.query else None,
-            "query_type": job.query_type.value if job.query else None,
+            "query_type": job.query_type.value if job.query and job.query_type else None,
             "target": job.target if job.target else None,
-            "target_type": job.target_type.value if job.target else None,
+            "target_type": job.target_type.value if job.target and job.target_type else None,
             "tool": job.tool.value if job.tool else None,
             "align":  job.align if job.align else None,
-            "align_type": job.align_type.value if job.align else None,
+            "align_type": job.align_type.value if job.align and job.align_type else None,
             "backup": job.backup if job.backup else None,
-            "backup_type": job.backup_type.value if job.backup else None,
+            "backup_type": job.backup_type.value if job.backup and job.backup_type else None,
             "options": " ".join(get_tools_options(job.tool.value, job.tool_options)) if job.tool_options else None
         })
     return result
@@ -800,6 +805,84 @@ def get_dotplot(path: JobPath):
         return {"code": 500, "message": paf.error}
     except FileNotFoundError:
         return {"code": 404, "message": "Job not found"}, 404
+
+
+@api.get('/result/<job_id>/tracks',
+         responses={
+             200: AnnotationTracksResponse,
+             404: NotFoundResponse,
+             500: BaseResponse,
+         })
+def get_annotation_tracks(path: JobPath):
+    """
+    List IGV annotation tracks available for a job.
+    """
+    try:
+        tracks = AnnotationTracks(APP_DATA).list_tracks(path.job_id)
+        return {"code": 0, "message": "ok", "data": {"tracks": tracks}}, 200
+    except FileNotFoundError:
+        return {"code": 404, "message": "Job not found"}, 404
+    except Exception:
+        logger.error(traceback.format_exc())
+        return {"code": 500, "message": "Internal error"}, 500
+
+
+@api.post('/result/<job_id>/tracks',
+          responses={
+              200: AnnotationTrackResponse,
+              400: BaseResponse,
+              404: NotFoundResponse,
+              413: BaseResponse,
+              415: BaseResponse,
+              500: BaseResponse,
+          })
+def upload_annotation_track(path: JobPath, form: AnnotationTrackUploadForm):
+    """
+    Upload a BED3 or Wiggle IGV annotation track for a job.
+    """
+    try:
+        track = AnnotationTracks(APP_DATA).save_track(
+            path.job_id,
+            form.axis.value,
+            form.file,
+            form.name,
+        )
+        return {"code": 0, "message": "ok", "data": track}, 200
+    except FileNotFoundError:
+        return {"code": 404, "message": "Job not found"}, 404
+    except AnnotationTrackError as error:
+        return {"code": 415, "message": str(error)}, 415
+    except RequestEntityTooLarge:
+        return {"code": 413, "message": "File too large"}, 413
+    except Exception:
+        logger.error(traceback.format_exc())
+        return {"code": 500, "message": "Internal error"}, 500
+
+
+@api.get('/result/<job_id>/track/<track_id>',
+         responses={
+             200: BaseResponse,
+             404: NotFoundResponse,
+             500: BaseResponse,
+         })
+def get_annotation_track_file(path: AnnotationTrackPath):
+    """
+    Serve an annotation track file for IGV.js.
+    """
+    try:
+        track_path, track = AnnotationTracks(APP_DATA).get_track_file(path.job_id, path.track_id)
+        return send_file(
+            track_path,
+            mimetype="text/plain",
+            as_attachment=False,
+            download_name=track["filename"],
+        )
+    except FileNotFoundError:
+        return {"code": 404, "message": "Track not found"}, 404
+    except Exception:
+        logger.error(traceback.format_exc())
+        return {"code": 500, "message": "Internal error"}, 500
+
 
 @api.get('/result/<job_id>/sorted-dotplot',
          responses={

--- a/src/dgenies/api/datamodels.py
+++ b/src/dgenies/api/datamodels.py
@@ -70,6 +70,15 @@ class ContigType(str, Enum):
     query = 'query'
     target = 'target'
 
+class AnnotationTrackAxis(str, Enum):
+    query = 'query'
+    target = 'target'
+
+class AnnotationTrackFormat(str, Enum):
+    bed = 'bed'
+    wig = 'wig'
+    bedgraph = 'bedgraph'
+
 class PrepareFastaEnum(str, Enum):
     done = 'Done'
     in_progress = 'In progress'
@@ -144,20 +153,20 @@ class JobId(BaseModel):
 class Job(JobId):
     type: JobType = Field(JobType.align, description="Type of job (align, plot or batch)")
 
-    query: str = Field(description="Query file. Can be either a filename or an url")
-    query_type: FileType = Field(description="Type of query file. Either 'local' or 'url'")
+    query: Optional[str] = Field(None, description="Query file. Can be either a filename or an url")
+    query_type: Optional[FileType] = Field(None, description="Type of query file. Either 'local' or 'url'")
 
-    target: str = Field(description="Target file. Can be either a filename or an url")
-    target_type: FileType = Field(description="Type of target file. Either 'local' or 'url'")
+    target: Optional[str] = Field(None, description="Target file. Can be either a filename or an url")
+    target_type: Optional[FileType] = Field(None, description="Type of target file. Either 'local' or 'url'")
 
-    align: str = Field(description="Align file. Can be either a filename or an url")
-    align_type: FileType = Field(description="Type of align file. Either 'local' or 'url'")
+    align: Optional[str] = Field(None, description="Align file. Can be either a filename or an url")
+    align_type: Optional[FileType] = Field(None, description="Type of align file. Either 'local' or 'url'")
 
-    backup: str = Field(description="Backup file. Can be either a filename or an url")
-    backup_type: FileType = Field(description="Type of backup file. Either 'local' or 'url'")
+    backup: Optional[str] = Field(None, description="Backup file. Can be either a filename or an url")
+    backup_type: Optional[FileType] = Field(None, description="Type of backup file. Either 'local' or 'url'")
 
-    tool: ToolName | None = Field(description="Tool file. Can be either 'minimap2' or 'mashmap'")
-    tool_options: Optional[list[str]] = Field([], description="List of options for chosen tool.")
+    tool: ToolName | None = Field(None, description="Tool file. Can be either 'minimap2' or 'mashmap'")
+    tool_options: list[str] = Field(default_factory=list, description="List of options for chosen tool.")
 
 class JobsSubmissionQuery(Session, Job):
 
@@ -210,6 +219,12 @@ class UploadFileForm(Session):
     file: FileStorage
 
 
+class AnnotationTrackUploadForm(BaseModel):
+    axis: AnnotationTrackAxis = Field(description="Axis the track is associated with")
+    name: Optional[str] = Field(None, description="Display name for the track")
+    file: FileStorage
+
+
 class UploadResponseData(NeededFiles):
     batch_id: str|None = Field(description="Job id, null until last upload is completed")
     job_ids: list[JobId]|None = Field(description="List of jobs ids, null if file upload is needed")
@@ -225,6 +240,9 @@ class JobPath(JobId):
 
 class JobFilePath(JobId):
     filename: str = Field(description="File name")
+
+class AnnotationTrackPath(JobPath):
+    track_id: str = Field(description="Annotation track id")
 
 class JobStatus(JobId):
     percent: float = Field(description="Progression of job. Takes value between 0 and 100. When the value reaches 100, the job is complete regardless of its status (success or error).")
@@ -263,6 +281,25 @@ class Dotplot(BaseModel):
 
 class DotplotResponse(BaseResponse):
     data: Dotplot
+
+class AnnotationTrack(BaseModel):
+    id: str = Field(description="Annotation track id")
+    job_id: str = Field(description="The id of the job")
+    axis: AnnotationTrackAxis = Field(description="Axis the track is associated with")
+    format: AnnotationTrackFormat = Field(description="Track file format")
+    name: str = Field(description="Display name")
+    filename: str = Field(description="Original uploaded filename")
+    size: int = Field(description="Track file size in bytes")
+    created_at: str = Field(description="Track upload timestamp")
+
+class AnnotationTracksList(BaseModel):
+    tracks: list[AnnotationTrack] = Field(description="Annotation tracks available for the job")
+
+class AnnotationTrackResponse(BaseResponse):
+    data: AnnotationTrack
+
+class AnnotationTracksResponse(BaseResponse):
+    data: AnnotationTracksList
 
 
 class SummaryResponse(BaseResponse):

--- a/src/dgenies/lib/annotation_tracks.py
+++ b/src/dgenies/lib/annotation_tracks.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from werkzeug.datastructures import FileStorage
+from werkzeug.utils import secure_filename
+
+
+TRACKS_DIR_NAME = "annotation_tracks"
+MANIFEST_FILENAME = "tracks.json"
+VALID_AXES = {"target", "query"}
+VALID_EXTENSIONS = {
+    ".bed": "bed",
+    ".wig": "wig",
+    ".wiggle": "wig",
+}
+
+
+class AnnotationTrackError(ValueError):
+    """Raised when an annotation track cannot be accepted."""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _safe_job_dir(app_data: str, job_id: str) -> Path:
+    if not re.match(r"^[A-Za-z0-9_.-]+$", job_id):
+        raise FileNotFoundError(job_id)
+
+    root = Path(app_data).resolve()
+    job_dir = (root / job_id).resolve()
+    if root not in job_dir.parents or not job_dir.is_dir():
+        raise FileNotFoundError(job_id)
+    return job_dir
+
+
+def _tracks_dir(job_dir: Path) -> Path:
+    path = job_dir / TRACKS_DIR_NAME
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _manifest_path(job_dir: Path) -> Path:
+    return _tracks_dir(job_dir) / MANIFEST_FILENAME
+
+
+def _load_manifest(job_dir: Path) -> list[dict[str, Any]]:
+    manifest = _manifest_path(job_dir)
+    if not manifest.exists():
+        return []
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return []
+    if not isinstance(data, list):
+        return []
+    return [entry for entry in data if isinstance(entry, dict)]
+
+
+def _save_manifest(job_dir: Path, tracks: list[dict[str, Any]]) -> None:
+    manifest = _manifest_path(job_dir)
+    tmp_manifest = manifest.with_suffix(".json.tmp")
+    tmp_manifest.write_text(json.dumps(tracks, indent=2, sort_keys=True), encoding="utf-8")
+    os.replace(tmp_manifest, manifest)
+
+
+def _detect_format(filename: str) -> tuple[str, str]:
+    lower_name = filename.lower()
+    for suffix, track_format in sorted(VALID_EXTENSIONS.items(), key=lambda item: len(item[0]), reverse=True):
+        if lower_name.endswith(suffix):
+            return track_format, suffix.lstrip(".")
+    raise AnnotationTrackError("Only BED3 (.bed) and Wiggle (.wig, .wiggle) files are supported.")
+
+
+def _parse_int(value: str, line_no: int, field_name: str) -> int:
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise AnnotationTrackError(f"Line {line_no}: {field_name} must be an integer.") from exc
+
+
+def _parse_float(value: str, line_no: int, field_name: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise AnnotationTrackError(f"Line {line_no}: {field_name} must be numeric.") from exc
+    if not math.isfinite(parsed):
+        raise AnnotationTrackError(f"Line {line_no}: {field_name} must be finite.")
+    return parsed
+
+
+def _is_metadata_line(line: str) -> bool:
+    lower_line = line.lower()
+    return lower_line.startswith("#") or lower_line.startswith("track ") or lower_line.startswith("browser ")
+
+
+def _validate_bed3(path: Path) -> None:
+    data_lines = 0
+    with path.open("r", encoding="utf-8", errors="replace") as infile:
+        for line_no, raw_line in enumerate(infile, start=1):
+            line = raw_line.strip()
+            if not line or _is_metadata_line(line):
+                continue
+
+            columns = line.split()
+            if len(columns) != 3:
+                raise AnnotationTrackError(f"Line {line_no}: BED3 files must contain exactly 3 columns.")
+            if not columns[0]:
+                raise AnnotationTrackError(f"Line {line_no}: chromosome name is required.")
+
+            start = _parse_int(columns[1], line_no, "start")
+            end = _parse_int(columns[2], line_no, "end")
+            if start < 0:
+                raise AnnotationTrackError(f"Line {line_no}: start must be greater than or equal to 0.")
+            if end <= start:
+                raise AnnotationTrackError(f"Line {line_no}: end must be greater than start.")
+            data_lines += 1
+
+    if data_lines == 0:
+        raise AnnotationTrackError("BED3 file does not contain any feature.")
+
+
+def _parse_wig_header(line: str, line_no: int) -> str | None:
+    columns = line.split()
+    keyword = columns[0].lower()
+    if keyword not in {"fixedstep", "variablestep"}:
+        return None
+
+    attributes: dict[str, str] = {}
+    for column in columns[1:]:
+        if "=" not in column:
+            raise AnnotationTrackError(f"Line {line_no}: invalid Wiggle header attribute.")
+        key, value = column.split("=", 1)
+        attributes[key.lower()] = value
+
+    if not attributes.get("chrom"):
+        raise AnnotationTrackError(f"Line {line_no}: Wiggle header must define chrom.")
+
+    if keyword == "fixedstep":
+        start = _parse_int(attributes.get("start", ""), line_no, "start")
+        step = _parse_int(attributes.get("step", ""), line_no, "step")
+        if start < 1:
+            raise AnnotationTrackError(f"Line {line_no}: fixedStep start must be greater than 0.")
+        if step < 1:
+            raise AnnotationTrackError(f"Line {line_no}: fixedStep step must be greater than 0.")
+
+    if "span" in attributes and _parse_int(attributes["span"], line_no, "span") < 1:
+        raise AnnotationTrackError(f"Line {line_no}: span must be greater than 0.")
+
+    return keyword
+
+
+def _validate_bedgraph_line(columns: list[str], line_no: int) -> bool:
+    if len(columns) != 4:
+        return False
+    start = _parse_int(columns[1], line_no, "start")
+    end = _parse_int(columns[2], line_no, "end")
+    _parse_float(columns[3], line_no, "value")
+    if start < 0:
+        raise AnnotationTrackError(f"Line {line_no}: start must be greater than or equal to 0.")
+    if end <= start:
+        raise AnnotationTrackError(f"Line {line_no}: end must be greater than start.")
+    return True
+
+
+def _validate_wig(path: Path) -> str:
+    data_lines = 0
+    mode: str | None = None
+    bedgraph = False
+
+    with path.open("r", encoding="utf-8", errors="replace") as infile:
+        for line_no, raw_line in enumerate(infile, start=1):
+            line = raw_line.strip()
+            if not line or _is_metadata_line(line):
+                continue
+
+            next_mode = _parse_wig_header(line, line_no)
+            if next_mode:
+                mode = next_mode
+                continue
+
+            columns = line.split()
+            if mode == "fixedstep":
+                if len(columns) != 1:
+                    raise AnnotationTrackError(f"Line {line_no}: fixedStep data must contain exactly 1 value.")
+                _parse_float(columns[0], line_no, "value")
+            elif mode == "variablestep":
+                if len(columns) != 2:
+                    raise AnnotationTrackError(f"Line {line_no}: variableStep data must contain position and value.")
+                position = _parse_int(columns[0], line_no, "position")
+                if position < 1:
+                    raise AnnotationTrackError(f"Line {line_no}: position must be greater than 0.")
+                _parse_float(columns[1], line_no, "value")
+            elif _validate_bedgraph_line(columns, line_no):
+                bedgraph = True
+            else:
+                raise AnnotationTrackError(f"Line {line_no}: Wiggle data must follow a fixedStep or variableStep header.")
+            data_lines += 1
+
+    if data_lines == 0:
+        raise AnnotationTrackError("Wiggle file does not contain any value.")
+    return "bedgraph" if bedgraph and mode is None else "wig"
+
+
+def _validate_track(path: Path, detected_format: str) -> str:
+    if detected_format == "bed":
+        _validate_bed3(path)
+        return "bed"
+    return _validate_wig(path)
+
+
+def _public_track(job_id: str, entry: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": entry["id"],
+        "job_id": job_id,
+        "axis": entry["axis"],
+        "format": entry["format"],
+        "name": entry["name"],
+        "filename": entry["filename"],
+        "size": entry["size"],
+        "created_at": entry["created_at"],
+    }
+
+
+class AnnotationTracks:
+    """Persistent BED/Wiggle tracks associated with a D-Genies job."""
+
+    def __init__(self, app_data: str):
+        self.app_data = app_data
+
+    def list_tracks(self, job_id: str) -> list[dict[str, Any]]:
+        job_dir = _safe_job_dir(self.app_data, job_id)
+        entries = _load_manifest(job_dir)
+        tracks_dir = _tracks_dir(job_dir)
+        return [
+            _public_track(job_id, entry)
+            for entry in entries
+            if isinstance(entry.get("id"), str)
+            and isinstance(entry.get("stored_filename"), str)
+            and (tracks_dir / entry["stored_filename"]).is_file()
+        ]
+
+    def save_track(self, job_id: str, axis: str, uploaded_file: FileStorage, name: str | None = None) -> dict[str, Any]:
+        if axis not in VALID_AXES:
+            raise AnnotationTrackError("Track axis must be either target or query.")
+        if not uploaded_file or not uploaded_file.filename:
+            raise AnnotationTrackError("No annotation file was provided.")
+
+        original_filename = Path(uploaded_file.filename).name
+        detected_format, extension = _detect_format(original_filename)
+        job_dir = _safe_job_dir(self.app_data, job_id)
+        tracks_dir = _tracks_dir(job_dir)
+        track_id = uuid.uuid4().hex
+        safe_original = secure_filename(original_filename) or f"track.{extension}"
+        stored_filename = f"{track_id}.{extension}"
+        stored_path = tracks_dir / stored_filename
+
+        uploaded_file.save(stored_path)
+        try:
+            if stored_path.stat().st_size == 0:
+                raise AnnotationTrackError("Annotation file is empty.")
+            actual_format = _validate_track(stored_path, detected_format)
+        except Exception:
+            stored_path.unlink(missing_ok=True)
+            raise
+
+        display_name = (name or Path(original_filename).stem).strip() or safe_original
+        entry = {
+            "id": track_id,
+            "axis": axis,
+            "format": actual_format,
+            "name": display_name[:120],
+            "filename": safe_original,
+            "stored_filename": stored_filename,
+            "size": stored_path.stat().st_size,
+            "created_at": _utc_now(),
+        }
+
+        entries = _load_manifest(job_dir)
+        entries.append(entry)
+        _save_manifest(job_dir, entries)
+        return _public_track(job_id, entry)
+
+    def get_track_file(self, job_id: str, track_id: str) -> tuple[Path, dict[str, Any]]:
+        if not re.match(r"^[A-Fa-f0-9]{32}$", track_id):
+            raise FileNotFoundError(track_id)
+
+        job_dir = _safe_job_dir(self.app_data, job_id)
+        tracks_dir = _tracks_dir(job_dir)
+        for entry in _load_manifest(job_dir):
+            if entry.get("id") != track_id or not isinstance(entry.get("stored_filename"), str):
+                continue
+            stored_path = tracks_dir / entry["stored_filename"]
+            if not stored_path.is_file():
+                raise FileNotFoundError(track_id)
+            return stored_path, _public_track(job_id, entry)
+        raise FileNotFoundError(track_id)


### PR DESCRIPTION
Adds persistent BED3/Wiggle annotation track storage and dotplot API endpoints. Also relaxes optional job file fields so align submissions are not rejected with Pydantic 422 before domain
    validation.